### PR TITLE
Place env file under k8s/minio

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=minioadmin

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - minio

--- a/k8s/base/minio/.env.example
+++ b/k8s/base/minio/.env.example
@@ -1,0 +1,2 @@
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=minioadmin

--- a/k8s/base/minio/deployment.yaml
+++ b/k8s/base/minio/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+        - name: minio
+          image: minio/minio:RELEASE.2025-05-24T17-08-30Z
+          args:
+            - server
+            - --console-address
+            - ":9001"
+            - /data
+          envFrom:
+            - secretRef:
+                name: minio-secret
+          ports:
+            - containerPort: 9000
+            - containerPort: 9001
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: minio-pvc

--- a/k8s/base/minio/kustomization.yaml
+++ b/k8s/base/minio/kustomization.yaml
@@ -1,0 +1,9 @@
+secretGenerator:
+  - name: minio-secret
+    envs:
+      - .env
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - pvc.yaml

--- a/k8s/base/minio/pvc.yaml
+++ b/k8s/base/minio/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/k8s/base/minio/service.yaml
+++ b/k8s/base/minio/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  selector:
+    app: minio
+  ports:
+    - name: api
+      port: 9000
+      targetPort: 9000
+    - name: console
+      port: 9001
+      targetPort: 9001


### PR DESCRIPTION
## Summary
- keep `.env` in project root for compose
- add `.env.example` under `k8s/base/minio`
- reference the local `.env` file in MinIO kustomization

## Testing
- `kubectl kustomize k8s/base` *(fails: kubectl: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c7499238832189b32e3067eb86f2