### PR TITLE
Add redis kustomization base

### DIFF
--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
   - minio
+  - redis

--- a/k8s/base/redis/deployment.yaml
+++ b/k8s/base/redis/deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7.4.1-alpine
+          ports:
+            - containerPort: 6379
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: redis-pvc

--- a/k8s/base/redis/kustomization.yaml
+++ b/k8s/base/redis/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - deployment.yaml
+  - service.yaml
+  - pvc.yaml

--- a/k8s/base/redis/pvc.yaml
+++ b/k8s/base/redis/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/k8s/base/redis/service.yaml
+++ b/k8s/base/redis/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379


### PR DESCRIPTION
## Summary
- create k8s/base/redis with Deployment, Service and PVC manifests
- reference redis in base kustomization

## Testing
- `kustomize build k8s/base` *(fails: kustomize not found)*

------
https://chatgpt.com/codex/tasks/task_e_684920675090832182da7ff4ca204693