### PR TITLE
Add health checks to Redis and Minio deployments

### DIFF
--- a/k8s/base/minio/deployment.yaml
+++ b/k8s/base/minio/deployment.yaml
@@ -26,6 +26,22 @@ spec:
           ports:
             - containerPort: 9000
             - containerPort: 9001
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: 9000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /minio/health/ready
+              port: 9000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
           volumeMounts:
             - name: data
               mountPath: /data

--- a/k8s/base/redis/deployment.yaml
+++ b/k8s/base/redis/deployment.yaml
@@ -17,6 +17,20 @@ spec:
           image: redis:7.4.1-alpine
           ports:
             - containerPort: 6379
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
           volumeMounts:
             - name: data
               mountPath: /data


### PR DESCRIPTION
## Summary
- add liveness/readiness probes for Redis
- add liveness/readiness probes for Minio

## Testing
- `npm test` in `backend` *(fails: Missing script)*
- `npm test` in `next-app` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684925ef098883219e755a615a1b1fda