### PR TITLE
Remove prod backend patch

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "ts-node-dev src/index.ts",
+    "dev": "ts-node-dev --poll src/index.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js"
   },

--- a/k8s/base/backend/deployment.yaml
+++ b/k8s/base/backend/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      containers:
+        - name: backend
+          image: hello-k8s-backend
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 4000
+          envFrom:
+            - secretRef:
+                name: minio-secret
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 4000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 4000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5

--- a/k8s/base/backend/kustomization.yaml
+++ b/k8s/base/backend/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/k8s/base/backend/service.yaml
+++ b/k8s/base/backend/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+spec:
+  selector:
+    app: backend
+  ports:
+    - port: 4000
+      targetPort: 4000

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,3 +1,4 @@
 resources:
   - minio
   - redis
+  - backend

--- a/k8s/overlays/dev/backend/deployment.yaml
+++ b/k8s/overlays/dev/backend/deployment.yaml
@@ -11,3 +11,12 @@ spec:
             - npm
             - run
             - dev
+          volumeMounts:
+            - name: backend-src
+              mountPath: /app/src
+              readOnly: false
+      volumes:
+        - name: backend-src
+          hostPath:
+            path: /workspace/hello-k8s/backend/src
+            type: Directory

--- a/k8s/overlays/dev/backend/deployment.yaml
+++ b/k8s/overlays/dev/backend/deployment.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+spec:
+  template:
+    spec:
+      containers:
+        - name: backend
+          command:
+            - npm
+            - run
+            - dev

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - ../../base
+patchesStrategicMerge:
+  - backend/deployment.yaml

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ../../base


### PR DESCRIPTION
## Summary
- removed the production overlay patch that only set `imagePullPolicy: Always`
- updated prod kustomization to point directly at the base resources
- set `imagePullPolicy: Never` for the backend container so it works with minikube

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68492c6689fc832195bb464a57c1ebaa