### PR TITLE
Allow overlay selection via OVERLAY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,12 @@ build:
 	docker build -t hello-k8s-next-app:latest next-app -f next-app/prod.Dockerfile;\
 	docker build -t hello-k8s-backend:latest backend -f backend/Dockerfile
 
+# Select overlay directory via OVERLAY (default: dev)
+OVERLAY ?= dev
+OVERLAY_DIR = k8s/overlays/$(OVERLAY)
+
 deploy:
-	kubectl apply -k k8s/base
+	kubectl apply -k $(OVERLAY_DIR)
 
 clean:
-	kubectl delete -k k8s/base
+	kubectl delete -k $(OVERLAY_DIR)


### PR DESCRIPTION
## Summary
- rename overlay variable to `OVERLAY`
- `deploy` and `clean` now use `OVERLAY` (defaults to `dev`)

## Testing
- `make -n deploy`
- `make -n deploy OVERLAY=prod`


------
https://chatgpt.com/codex/tasks/task_e_68494c32335883219d62fd3be522593c