### PR TITLE
Add Kubernetes config for next-app

### DIFF
--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -2,3 +2,4 @@ resources:
   - minio
   - redis
   - backend
+  - next-app

--- a/k8s/base/next-app/deployment.yaml
+++ b/k8s/base/next-app/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: next-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: next-app
+  template:
+    metadata:
+      labels:
+        app: next-app
+    spec:
+      containers:
+        - name: next-app
+          image: hello-k8s-next-app
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 3000

--- a/k8s/base/next-app/kustomization.yaml
+++ b/k8s/base/next-app/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/k8s/base/next-app/service.yaml
+++ b/k8s/base/next-app/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: next-app
+spec:
+  selector:
+    app: next-app
+  ports:
+    - port: 3000
+      targetPort: 3000

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -2,3 +2,4 @@ resources:
   - ../../base
 patchesStrategicMerge:
   - backend/deployment.yaml
+  - next-app/deployment.yaml

--- a/k8s/overlays/dev/next-app/deployment.yaml
+++ b/k8s/overlays/dev/next-app/deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: next-app
+spec:
+  template:
+    spec:
+      containers:
+        - name: next-app
+          image: hello-k8s-next-app-dev
+          volumeMounts:
+            - name: next-app-src
+              mountPath: /app/src
+              readOnly: false
+            - name: next-app-public
+              mountPath: /app/public
+              readOnly: false
+      volumes:
+        - name: next-app-src
+          hostPath:
+            path: /workspace/hello-k8s/next-app/src
+            type: Directory
+        - name: next-app-public
+          hostPath:
+            path: /workspace/hello-k8s/next-app/public
+            type: Directory


### PR DESCRIPTION
## Summary
- deploy `next-app` via kustomize
- add dev overlay for live reloading using a different image

## Testing
- `npm run build` in `backend` *(fails: Cannot find module...)*
- `npm run build` in `next-app` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684952094f108321ac69b030b75f3af4