### PR TITLE
Add Caddy deployment for Kubernetes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 MINIO_ROOT_USER=minioadmin
 MINIO_ROOT_PASSWORD=minioadmin
+TLS_EMAIL=you@example.com
+DOMAIN_NAME=example.com

--- a/k8s/base/caddy/configmap.yaml
+++ b/k8s/base/caddy/configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: caddy-config
+  labels:
+    app: caddy
+data:
+  Caddyfile: |
+    {$DOMAIN_NAME:localhost} {
+        tls {$TLS_EMAIL:internal}
+
+        handle /api/* {
+            reverse_proxy backend:4000
+        }
+
+        handle /admin/* {
+            reverse_proxy backend:4000
+        }
+
+        handle {
+            reverse_proxy next-app:3000
+        }
+    }

--- a/k8s/base/caddy/deployment.yaml
+++ b/k8s/base/caddy/deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: caddy
+  labels:
+    app: caddy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: caddy
+  template:
+    metadata:
+      labels:
+        app: caddy
+    spec:
+      containers:
+        - name: caddy
+          image: caddy:2.10.0-alpine
+          ports:
+            - containerPort: 80
+            - containerPort: 443
+          volumeMounts:
+            - name: caddyfile
+              mountPath: /etc/caddy/Caddyfile
+              subPath: Caddyfile
+            - name: data
+              mountPath: /data
+            - name: config
+              mountPath: /config
+      volumes:
+        - name: caddyfile
+          configMap:
+            name: caddy-config
+            items:
+              - key: Caddyfile
+                path: Caddyfile
+        - name: data
+          emptyDir: {}
+        - name: config
+          emptyDir: {}

--- a/k8s/base/caddy/kustomization.yaml
+++ b/k8s/base/caddy/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml

--- a/k8s/base/caddy/service.yaml
+++ b/k8s/base/caddy/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: caddy
+  labels:
+    app: caddy
+spec:
+  selector:
+    app: caddy
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+    - name: https
+      port: 443
+      targetPort: 443

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -3,3 +3,4 @@ resources:
   - redis
   - backend
   - next-app
+  - caddy

--- a/k8s/overlays/prod/caddy/.env.example
+++ b/k8s/overlays/prod/caddy/.env.example
@@ -1,0 +1,2 @@
+TLS_EMAIL=you@example.com
+DOMAIN_NAME=example.com

--- a/k8s/overlays/prod/caddy/deployment.yaml
+++ b/k8s/overlays/prod/caddy/deployment.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: caddy
+spec:
+  template:
+    spec:
+      containers:
+        - name: caddy
+          envFrom:
+            - secretRef:
+                name: caddy-secret

--- a/k8s/overlays/prod/caddy/kustomization.yaml
+++ b/k8s/overlays/prod/caddy/kustomization.yaml
@@ -1,0 +1,8 @@
+resources:
+  - ../../base/caddy
+patchesStrategicMerge:
+  - deployment.yaml
+secretGenerator:
+  - name: caddy-secret
+    envs:
+      - .env

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
   - ../../base
+  - caddy


### PR DESCRIPTION
## Summary
- add a ConfigMap containing the Caddyfile
- deploy Caddy with the new config and expose with a service
- include the caddy component in the base kustomization

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_68495b21a708832185f9a442978c3341