### PR TITLE
Add initContainers to wait for dependencies

### DIFF
--- a/k8s/base/backend/deployment.yaml
+++ b/k8s/base/backend/deployment.yaml
@@ -12,6 +12,21 @@ spec:
       labels:
         app: backend
     spec:
+      initContainers:
+        - name: wait-for-deps
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              until nc -z redis 6379; do
+                echo "Waiting for redis...";
+                sleep 2;
+              done;
+              until nc -z minio 9000; do
+                echo "Waiting for minio...";
+                sleep 2;
+              done;
       containers:
         - name: backend
           image: hello-k8s-backend

--- a/k8s/base/next-app/deployment.yaml
+++ b/k8s/base/next-app/deployment.yaml
@@ -12,6 +12,17 @@ spec:
       labels:
         app: next-app
     spec:
+      initContainers:
+        - name: wait-for-backend
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              until nc -z backend 4000; do
+                echo "Waiting for backend...";
+                sleep 2;
+              done;
       containers:
         - name: next-app
           image: hello-k8s-next-app

--- a/k8s/base/worker/deployment.yaml
+++ b/k8s/base/worker/deployment.yaml
@@ -12,6 +12,21 @@ spec:
       labels:
         app: worker
     spec:
+      initContainers:
+        - name: wait-for-deps
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              until nc -z redis 6379; do
+                echo "Waiting for redis...";
+                sleep 2;
+              done;
+              until nc -z minio 9000; do
+                echo "Waiting for minio...";
+                sleep 2;
+              done;
       containers:
         - name: worker
           image: hello-k8s-backend


### PR DESCRIPTION
## Summary
- update base backend Deployment to wait for Redis and Minio before starting
- update base worker Deployment in the same way

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684970009fd083219a5175645fbb8cd2