### PR TITLE
Scale replicas in prod

### DIFF
--- a/k8s/overlays/prod/backend/deployment.yaml
+++ b/k8s/overlays/prod/backend/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   name: backend
 spec:
+  replicas: 2
   template:
     spec:
       containers:

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -8,3 +8,4 @@ patchesStrategicMerge:
   - backend/deployment.yaml
   - worker/deployment.yaml
   - caddy/deployment.yaml
+  - next-app/deployment.yaml

--- a/k8s/overlays/prod/next-app/deployment.yaml
+++ b/k8s/overlays/prod/next-app/deployment.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: next-app
+spec:
+  replicas: 2

--- a/k8s/overlays/prod/worker/deployment.yaml
+++ b/k8s/overlays/prod/worker/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   name: worker
 spec:
+  replicas: 2
   template:
     spec:
       containers:


### PR DESCRIPTION
## Summary
- scale backend, worker and next-app pods to 2 replicas in the prod overlay

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6849746e1f0883219479b42455f63b8d